### PR TITLE
Add support for JSON-API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ results
 npm-debug.log
 node_modules
 coverage/
+
+.idea/

--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ module.exports = function (opts) {
       return yield* next;
     }
 
-    if (this.request.is('application/json', 'application/csp-report')) {
+    if (this.request.is('application/json', 'application/vnd.api+json', 'application/csp-report')) {
       this.request.body = yield parse.json(this, jsonOpts);
     } else if (this.request.is('application/x-www-form-urlencoded')) {
       this.request.body = yield parse.form(this, formOpts);

--- a/test/middleware.test.js
+++ b/test/middleware.test.js
@@ -42,6 +42,22 @@ describe('test/middleware.test.js', function () {
       .expect({ foo: 'bar' }, done);
     });
 
+    it('should parse json body with json-api headers ok', function (done) {
+      // should work when use body parser again
+      app.use(bodyParser());
+
+      app.use(function *() {
+        this.request.body.should.eql( {foo: 'bar'} );
+        this.body = this.request.body;
+      });
+      request(app.listen())
+        .post('/')
+        .set('Accept', 'application/vnd.api+json')
+        .set('Content-type', 'application/vnd.api+json')
+        .send('{"foo": "bar"}')
+        .expect({ foo: 'bar' }, done);
+    });
+
     it('should json body reach the limit size', function (done) {
       var app = App({jsonLimit: 100});
       app.use(function *() {


### PR DESCRIPTION
Add support for jsonapi.org format.

JSON API requires use of the JSON API media type (application/vnd.api+json) for exchanging data.

Simple code update and test added.
