### PR TITLE
Support Content-Type application/jwt

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,6 +56,7 @@ module.exports = function (opts) {
 
   // default text types
   var textTypes = [
+    'application/jwt',
     'text/plain',
   ];
 

--- a/test/middleware.test.js
+++ b/test/middleware.test.js
@@ -208,6 +208,22 @@ describe('test/middleware.test.js', function () {
       .send('body')
       .expect({}, done);
     });
+
+    it('should parse application/jwt body contents', function (done) {
+      var app = App({
+        enableTypes: ['text', 'json'],
+      });
+      app.use(async (ctx) => {
+        ctx.request.body.should.equal('body');
+        ctx.request.rawBody.should.equal('body');
+        ctx.body = ctx.request.body;
+      });
+      request(app.listen())
+      .post('/')
+      .type('application/jwt')
+      .send('body')
+      .expect('body', done);
+    })
   });
 
   describe('extent type', function () {


### PR DESCRIPTION
The Content-Type `application/jwt` [seems to be a thing now](https://www.iana.org/assignments/media-types/application/jwt) for plain JWT bodies and we would like to use them.

This tiny PR just makes the body parser recognize `application/jwt` as a text body.