### PR TITLE
Let's add ability to parse content type `multipart/form-data`

### DIFF
--- a/example.js
+++ b/example.js
@@ -1,12 +1,12 @@
 var koa = require('koa');
 var bodyParser = require('./');
 
-var app = koa();
-app.use(bodyParser());
+var app = new koa();
+app.use(bodyParser({ enableTypes: ['json', 'form', 'multipart'] }));
 
 app.use(function *() {
   // the parsed body will store in this.request.body
-  this.body = this.request.body;
+  this.body = this.request.body
 });
 
 app.listen(3000);

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
   },
   "dependencies": {
     "co-body": "^5.1.0",
-    "copy-to": "^2.0.1"
+    "copy-to": "^2.0.1",
+    "formidable": "^1.1.1"
   },
   "engines": {
     "node": ">=7.6"


### PR DESCRIPTION
One of the content type that has not beed covered is `multipart/form-data`. This is very important for file uploading. Let's add, while still optional

- Add formidable package
- Parse multipart/form-data