### PR TITLE
customBodyFieldName

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,7 +74,7 @@ module.exports = function (opts) {
     if (ctx.disableBodyParser) return await next();
     try {
       const res = await parseBody(ctx);
-      ctx.request.body = 'parsed' in res ? res.parsed : {};
+      ctx.request[opts.customBodyFieldName || 'body'] = 'parsed' in res ? res.parsed : {};
       if (ctx.request.rawBody === undefined) ctx.request.rawBody = res.raw;
     } catch (err) {
       if (onerror) {


### PR DESCRIPTION
I'm using `koa-joi-router`,
I have such a validation:
```js
  validate: {
    type: 'multipart',
  },
```

when `ctx.request.body` is defined, the validation passes even when it should fail so the simplest solution is to rename this field