### PR TITLE
Prevent opts singleton being passed into co-body

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,17 +88,21 @@ module.exports = function (opts) {
 
   async function parseBody(ctx) {
     if (enableJson && ((detectJSON && detectJSON(ctx)) || ctx.request.is(jsonTypes))) {
-      return await parse.json(ctx, jsonOpts);
+      return await parse.json(ctx, clone(jsonOpts));
     }
     if (enableForm && ctx.request.is(formTypes)) {
-      return await parse.form(ctx, formOpts);
+      return await parse.form(ctx, clone(formOpts));
     }
     if (enableText && ctx.request.is(textTypes)) {
-      return await parse.text(ctx, textOpts) || '';
+      return await parse.text(ctx, clone(textOpts)) || '';
     }
     return {};
   }
 };
+
+function clone(input) {
+  return Object.assign({}, input);
+}
 
 function formatOptions(opts, type) {
   var res = {};


### PR DESCRIPTION
`co-body` will set `opts.length` if the header `content-length` is present in the request. If any subsequent requests follow that _dont_ have `content-length` (i.e. chunked) the previous value is used, this will trigger a content length mismatch error. Passing a clean `opts` object will prevent this