### PR TITLE
feat: support xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ app.use(async ctx => {
 * **textLimit**: limit of the `text` body. Default is `1mb`.
 * **strict**: when set to true, JSON parser will only accept arrays and objects. Default is `true`. See [strict mode](https://github.com/cojs/co-body#options) in `co-body`. In strict mode, `ctx.request.body` will always be an object(or array), this avoid lots of type judging. But text body will always return string type.
 * **detectJSON**: custom json request detect function. Default is `null`.
+* **defaultAsText**: treat as `text` when `Content-Type` is unset. Default is `false`.
 
   ```js
   app.use(bodyparser({

--- a/README.md
+++ b/README.md
@@ -48,14 +48,14 @@ app.use(async ctx => {
 
 ## Options
 
-* **enableTypes**: parser will only parse when request type hits enableTypes, default is `['json', 'form']`.
+* **enableTypes**: parser will only parse when request type hits enableTypes, support `json/form/text/xml`, default is `['json', 'form']`.
 * **encoding**: requested encoding. Default is `utf-8` by `co-body`.
 * **formLimit**: limit of the `urlencoded` body. If the body ends up being larger than this limit, a 413 error code is returned. Default is `56kb`.
 * **jsonLimit**: limit of the `json` body. Default is `1mb`.
 * **textLimit**: limit of the `text` body. Default is `1mb`.
+* **xmlLimit**: limit of the `xml` body. Default is `1mb`.
 * **strict**: when set to true, JSON parser will only accept arrays and objects. Default is `true`. See [strict mode](https://github.com/cojs/co-body#options) in `co-body`. In strict mode, `ctx.request.body` will always be an object(or array), this avoid lots of type judging. But text body will always return string type.
 * **detectJSON**: custom json request detect function. Default is `null`.
-* **defaultAsText**: treat as `text` when `Content-Type` is unset. Default is `false`.
 
   ```js
   app.use(bodyparser({

--- a/index.js
+++ b/index.js
@@ -29,6 +29,7 @@ module.exports = function (opts) {
   opts = opts || {};
   var detectJSON = opts.detectJSON;
   var onerror = opts.onerror;
+  var defaultAsText = opts.defaultAsText;
 
   var enableTypes = opts.enableTypes || ['json', 'form'];
   var enableForm = checkEnable(enableTypes, 'form');
@@ -37,6 +38,7 @@ module.exports = function (opts) {
 
   opts.detectJSON = undefined;
   opts.onerror = undefined;
+  opts.defaultAsText = undefined;
 
   // force co-body return raw body
   opts.returnRawBody = true;
@@ -94,6 +96,9 @@ module.exports = function (opts) {
       return await parse.form(ctx, formOpts);
     }
     if (enableText && ctx.request.is(textTypes)) {
+      return await parse.text(ctx, textOpts) || '';
+    }
+    if (defaultAsText && !ctx.get('content-type')) {
       return await parse.text(ctx, textOpts) || '';
     }
     return {};

--- a/index.js
+++ b/index.js
@@ -29,16 +29,15 @@ module.exports = function (opts) {
   opts = opts || {};
   var detectJSON = opts.detectJSON;
   var onerror = opts.onerror;
-  var defaultAsText = opts.defaultAsText;
 
   var enableTypes = opts.enableTypes || ['json', 'form'];
   var enableForm = checkEnable(enableTypes, 'form');
   var enableJson = checkEnable(enableTypes, 'json');
   var enableText = checkEnable(enableTypes, 'text');
+  var enableXml = checkEnable(enableTypes, 'xml');
 
   opts.detectJSON = undefined;
   opts.onerror = undefined;
-  opts.defaultAsText = undefined;
 
   // force co-body return raw body
   opts.returnRawBody = true;
@@ -61,15 +60,23 @@ module.exports = function (opts) {
     'text/plain',
   ];
 
+  // default xml types
+  var xmlTypes = [
+    'text/xml',
+    'application/xml',
+  ];
+
   var jsonOpts = formatOptions(opts, 'json');
   var formOpts = formatOptions(opts, 'form');
   var textOpts = formatOptions(opts, 'text');
+  var xmlOpts = formatOptions(opts, 'xml');
 
   var extendTypes = opts.extendTypes || {};
 
   extendType(jsonTypes, extendTypes.json);
   extendType(formTypes, extendTypes.form);
   extendType(textTypes, extendTypes.text);
+  extendType(xmlTypes, extendTypes.xml);
 
   return async function bodyParser(ctx, next) {
     if (ctx.request.body !== undefined) return await next();
@@ -98,8 +105,8 @@ module.exports = function (opts) {
     if (enableText && ctx.request.is(textTypes)) {
       return await parse.text(ctx, textOpts) || '';
     }
-    if (defaultAsText && !ctx.get('content-type')) {
-      return await parse.text(ctx, textOpts) || '';
+    if (enableXml && ctx.request.is(xmlTypes)) {
+      return await parse.text(ctx, xmlOpts) || '';
     }
     return {};
   }

--- a/test/middleware.test.js
+++ b/test/middleware.test.js
@@ -210,43 +210,56 @@ describe('test/middleware.test.js', function () {
     });
   });
 
-  describe('defaultAsText', function () {
-    it('should parse as Text', function (done) {
+  describe('xml body', function () {
+    it('should parse xml body ok', function (done) {
       var app = App({
-        defaultAsText: true,
+        enableTypes: ['xml'],
       });
       app.use(async (ctx) => {
-        ctx.headers['content-type'].should.equal('');
-        ctx.request.body.should.equal('body');
-        ctx.request.rawBody.should.equal('body');
+        ctx.headers['content-type'].should.equal('application/xml');
+        ctx.request.body.should.equal('<xml>abc</xml>');
+        ctx.request.rawBody.should.equal('<xml>abc</xml>');
         ctx.body = ctx.request.body;
       });
       request(app.listen())
-        .post('/')
-        .send('body')
-        .set('content-type', '')
-        .type('')
-        .expect('body', done);
+      .post('/')
+      .type('xml')
+      .send('<xml>abc</xml>')
+      .expect('<xml>abc</xml>', done);
     });
 
-    it('should not parse', function (done) {
+    it('should not parse text body when disable', function (done) {
       var app = App();
       app.use(async (ctx) => {
-        ctx.headers[ 'content-type' ].should.equal('');
-        ctx.request.body.should.eql({});
+        ctx.headers['content-type'].should.equal('application/xml');
+        ctx.body = ctx.request.body;
+      });
+      request(app.listen())
+      .post('/')
+      .type('xml')
+      .send('<xml>abc</xml>')
+      .expect({}, done);
+    });
+
+    it('should xml body reach the limit size', function (done) {
+      var app = App({
+        enableTypes: ['xml'],
+        xmlLimit: 10,
+      });
+      app.use(async (ctx) => {
+        ctx.headers['content-type'].should.equal('application/xml');
         ctx.body = ctx.request.body;
       });
       request(app.listen())
         .post('/')
-        .send('body')
-        .set('content-type', '')
-        .type('')
-        .expect({}, done);
+        .type('xml')
+        .send('<xml>abcdefghijklmn</xml>')
+        .expect(413, done);
     });
   });
 
-  describe('extent type', function () {
-    it('should extent json ok', function (done) {
+  describe('extend type', function () {
+    it('should extend json ok', function (done) {
       var app = App({
         extendTypes: {
           json: 'application/x-javascript'
@@ -263,7 +276,7 @@ describe('test/middleware.test.js', function () {
         .expect({ foo: 'bar' }, done);
     });
 
-    it('should extent json with array ok', function (done) {
+    it('should extend json with array ok', function (done) {
       var app = App({
         extendTypes: {
           json: ['application/x-javascript', 'application/y-javascript']
@@ -278,6 +291,24 @@ describe('test/middleware.test.js', function () {
         .type('application/x-javascript')
         .send(JSON.stringify({ foo: 'bar' }))
         .expect({ foo: 'bar' }, done);
+    });
+
+    it('should extend xml ok', function (done) {
+      var app = App({
+        enableTypes: ['xml'],
+        extendTypes: {
+          xml: 'application/xml-custom'
+        }
+      });
+      app.use(async (ctx) => {
+        ctx.body = ctx.request.body;
+      });
+
+      request(app.listen())
+        .post('/')
+        .type('application/xml-custom')
+        .send('<xml>abc</xml>')
+        .expect('<xml>abc</xml>', done);
     });
   });
 

--- a/test/middleware.test.js
+++ b/test/middleware.test.js
@@ -210,6 +210,41 @@ describe('test/middleware.test.js', function () {
     });
   });
 
+  describe('defaultAsText', function () {
+    it('should parse as Text', function (done) {
+      var app = App({
+        defaultAsText: true,
+      });
+      app.use(async (ctx) => {
+        ctx.headers['content-type'].should.equal('');
+        ctx.request.body.should.equal('body');
+        ctx.request.rawBody.should.equal('body');
+        ctx.body = ctx.request.body;
+      });
+      request(app.listen())
+        .post('/')
+        .send('body')
+        .set('content-type', '')
+        .type('')
+        .expect('body', done);
+    });
+
+    it('should not parse', function (done) {
+      var app = App();
+      app.use(async (ctx) => {
+        ctx.headers[ 'content-type' ].should.equal('');
+        ctx.request.body.should.eql({});
+        ctx.body = ctx.request.body;
+      });
+      request(app.listen())
+        .post('/')
+        .send('body')
+        .set('content-type', '')
+        .type('')
+        .expect({}, done);
+    });
+  });
+
   describe('extent type', function () {
     it('should extent json ok', function (done) {
       var app = App({


### PR DESCRIPTION
only parse xml as text to `ctx.request.body`, not try to parse it with xml lib.