### PR TITLE
Support scim json format

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,8 @@ module.exports = function(opts) {
     'application/json',
     'application/json-patch+json',
     'application/vnd.api+json',
-    'application/csp-report'
+    'application/csp-report',
+    'application/scim+json'
   ];
 
   // default form types


### PR DESCRIPTION
As I'm recently starting to integrate the Okta SCIM into our system, I've discovered this lib doesn't provide a flexible way to extend the `content-type` for SCIM-JSON that the protocol asks for, here comes the proposal/workaround.

> BTW: Maybe another better way is to expose the extension of `jsonTypes` outside the code :)

Here's the protocol detail: https://www.rfc-editor.org/rfc/rfc7644#section-3.12



## Checklist

- [x] I have ensured my pull request is not behind the main or master branch of the original repository.
- [x] I have rebased all commits where necessary so that reviewing this pull request can be done without having to merge it first.
- [x] I have written a commit message that passes commitlint linting.
- [x] I have ensured that my code changes pass linting tests.
- [x] I have ensured that my code changes pass unit tests.
- [x] I have described my pull request and the reasons for code changes along with context if necessary.
