### PR TITLE
chore: export BodyParserOptions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,3 +3,5 @@ export {
   bodyParserWrapper as bodyParser,
   bodyParserWrapper as default,
 } from './body-parser';
+
+export type {BodyParserOptions} from './body-parser.types';


### PR DESCRIPTION
The original `@types/koa-bodyparser` has this `Options` export: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/koa-bodyparser/index.d.ts#L32-L87

Add it back to support this usage.

## Checklist

- [x] I have ensured my pull request is not behind the main or master branch of the original repository.
- [x] I have rebased all commits where necessary so that reviewing this pull request can be done without having to merge it first.
- [x] I have written a commit message that passes commitlint linting.
- [x] I have ensured that my code changes pass linting tests.
- [x] I have ensured that my code changes pass unit tests.
- [x] I have described my pull request and the reasons for code changes along with context if necessary.
