### PR TITLE
feat: set name of middleware function to improve interop with monitoring tools

### DIFF
--- a/src/body-parser.ts
+++ b/src/body-parser.ts
@@ -73,7 +73,8 @@ export function bodyParserWrapper(opts: BodyParserOptions = {}) {
     >;
   }
 
-  return async function (ctx: Koa.Context, next: Koa.Next) {
+  // eslint-disable-next-line func-names
+  return async function bodyParser(ctx: Koa.Context, next: Koa.Next) {
     if (
       // method souldn't be parsed
       !parsedMethods.includes(ctx.method.toUpperCase()) ||


### PR DESCRIPTION
Set name of middleware function to improve interop with monitoring tools.

Tools like [@opentelemetry/instrumentation-koa](https://www.npmjs.com/package/@opentelemetry/instrumentation-koa) use function names to generate span names. These names appear in UI of monitoring tools, such as datadog.

Because the returned function doesn't have a name, there's no hint about the actual middleware associated with that span. See below:

<img width="227" alt="Screenshot 2024-03-24 at 13 03 42" src="https://github.com/koajs/bodyparser/assets/1017236/e60cad1c-d348-4d2b-baca-486d0396ed9e">

In v4 the returned middleware had a name but in v5 got removed, see: https://github.com/koajs/bodyparser/blob/5678a79e64d7833e0dd7734c9e9de40126e14d98/index.js#L63.

## Checklist

- [x] I have ensured my pull request is not behind the main or master branch of the original repository.
- [x] I have rebased all commits where necessary so that reviewing this pull request can be done without having to merge it first.
- [x] I have written a commit message that passes commitlint linting.
- [x] I have ensured that my code changes pass linting tests.
- [x] I have ensured that my code changes pass unit tests.
- [x] I have described my pull request and the reasons for code changes along with context if necessary.
