### PR TITLE
fix: set `@types/cobody` as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "@types/co-body": "^6.1.0",
     "@types/jest": "^29.5.0",
     "@types/koa": "^2.13.6",
     "@types/lodash.merge": "^4.6.7",
@@ -65,6 +64,7 @@
     "xo": "^0.54.2"
   },
   "dependencies": {
+    "@types/co-body": "^6.1.0",
     "co-body": "^6.1.0",
     "lodash.merge": "^4.6.2",
     "type-is": "^1.6.18"


### PR DESCRIPTION
To switch to @koa/bodyparser we have to [awkwardly](https://github.com/seek-oss/skuba/pull/1605/files/163bb4c83bc5a99dc239427638e7b4ab5fd8970c#diff-39451b878c65c8e692521921cfd21ca3c8c1a7367bb5845570f7a0c5202b522eR36) declare a dependency on `@types/cobody` or resort to using `skipLibCheck` as this library is [referencing types](https://github.com/koajs/bodyparser/blob/031348a2d469dd288dc21cd10d8de280d9936f2c/src/body-parser.types.ts#L1) it whilst declaring it as a devDependency.

This PR sets @types/cobody as a dependency.

## Checklist

- [x] I have ensured my pull request is not behind the main or master branch of the original repository.
- [x] I have rebased all commits where necessary so that reviewing this pull request can be done without having to merge it first.
- [x] I have written a commit message that passes commitlint linting.
- [x] I have ensured that my code changes pass linting tests.
- [x] I have ensured that my code changes pass unit tests.
- [x] I have described my pull request and the reasons for code changes along with context if necessary.
